### PR TITLE
Updated body-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "ajv": "~4.10.3",
     "ap": "~0.2.0",
-    "body-parser": "~1.15.2",
+    "body-parser": "~1.18.2",
     "delayed-response": "~2.0.0",
     "error": "~7.0.2",
     "fn-unary": "~1.0.0",


### PR DESCRIPTION
There is a remote code execution bug in old versions of qs, which is used by the old version of body-parser in swole. This updates that dependency. Tests run under node 6, but are broken (even without the update) on versions 8 and 10.

Could you please merge this PR and publish a new version of swole to npm? Thank you!