### PR TITLE
Validate createError: fix formatting when !e.dataPath

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -154,7 +154,7 @@ const StatusError = TypedError({
 function createError (Ctor, errors, data, source) {
   return Ctor({
     source: source,
-    cause: errors.map((e) => `${e.dataPath} ${e.message}`).join(', '),
+    cause: errors.map((e) => [e.dataPath, e.message].filter(Boolean).join(', '),
     errors: errors
   })
 }


### PR DESCRIPTION
error.dataPath is empty when root errors occur, like when no body is given but an object is expected.